### PR TITLE
Correction du cron pour exécuter le job du lundi au vendredi et non pas du mardi au samedi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ workflows:
             - compute
     triggers:
       - schedule:
-          cron: 0 6 * * 2,3,4,5,6
+          cron: 0 6 * * 1-5
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,21 +115,29 @@ workflows:
       - compute:
           requires:
             - install_requirements
+  daily-data:
+    jobs:
+      - get_data
+    triggers:
+      - schedule:
+          cron: 0 4 * * 1-6
+          filters:
+            branches:
+              only:
+                - master
 
   daily-prod:
     jobs:
       - install_requirements
-      - get_data
       - compute:
           requires:
             - install_requirements
-            - get_data
       - send:
           requires:
             - compute
     triggers:
       - schedule:
-          cron: 0 6 * * 1-5
+          cron: 0 6 * * 2-6
           filters:
             branches:
               only:


### PR DESCRIPTION
Actuellement le cron est configuré pour s'exécuter du mardi au samedi.

De ce fait, le lundi, il n'y a pas de cache sur les données et donc les MRs plante car n'ont pas de données.