### PR TITLE
Ajout de l'étape get_data avec activation manuelle dans les MRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - restore_cache:
           keys:
             - dependencies-{{ .Branch }}-{{ checksum "requirements.txt"}}-{{ checksum "config-circleci.json"}}
-            - dependencies-master-{{ checksum "requirements.txt"}}
+            - dependencies-master-{{ checksum "requirements.txt"}}-{{ checksum "config-circleci.json"}}
       - run: cp config-circleci.json config.json
       - run:
           name: Installation des requirements
@@ -76,7 +76,7 @@ jobs:
       - restore_cache:
           keys:
             - dependencies-{{ .Branch }}-{{ checksum "requirements.txt"}}-{{ checksum "config-circleci.json"}}
-            - dependencies
+            - dependencies-master-{{ checksum "requirements.txt"}}-{{ checksum "config-circleci.json"}}
       - run: date +%F > date
       - restore_cache:
           keys:
@@ -121,6 +121,7 @@ workflows:
       - compute:
           requires:
             - install_requirements
+
   daily-data:
     jobs:
       - get_data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           keys:
             - dependencies-{{ .Branch }}-{{ checksum "requirements.txt"}}-{{ checksum "config-circleci.json"}}
             - dependencies-master-{{ checksum "requirements.txt"}}
-      - run: mv config-circleci.json config.json
+      - run: cp config-circleci.json config.json
       - run:
           name: Installation des requirements
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
               wget https://www.data.gouv.fr/fr/datasets/r/16962018-5c31-4296-9454-5998585496d2 -O decp.json
               ls
         - save_cache:
-           key: data-input-{{ checksum "date" }}
+           key: data-input-{{ .Branch }}-{{ checksum "date" }}
            paths:
              - "data"
 
@@ -80,7 +80,8 @@ jobs:
       - run: date +%F > date
       - restore_cache:
           keys:
-            - data-input-{{ checksum "date" }}
+            - data-input-{{ .Branch }}-{{ checksum "date" }}
+            - data-input-master-{{ checksum "date" }}
       - run:
           name: Traitement des données
           no_output_timeout: 2h
@@ -111,6 +112,11 @@ workflows:
   version: 2
   main:
     jobs:
+      - hold: # <<< A job that will require manual approval in the CircleCI web application.
+          type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
+      - get_data:
+          requires:
+            - hold # Will only be validated if approved so get_data won't run until then
       - install_requirements
       - compute:
           requires:


### PR DESCRIPTION
De cette manière si dans une MR, nous changeons les sources de données, nous sommes capable de regénérer le cache associé dans la MR afin de valider le fonctionnement attendu